### PR TITLE
Accept options for SSL, authSource, and ReplSetName

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -41,11 +41,7 @@ function getConnection(opts, cb) {
     svr = new mongodb.Server(opts.host, opts.port, {});
   }
 
-  var connectOpts = {safe: true};
-  if (opts.authSource != null ) {
-    connectOpts.authSource = opts.authSource;
-  }
-  new mongodb.Db(opts.db, svr, connectOpts).open(function (err, db) {
+  new mongodb.Db(opts.db, svr, {safe: true}).open(function (err, db) {
 		if (err) {
 			return cb(err);
 		}
@@ -68,8 +64,12 @@ function getConnection(opts, cb) {
       });
     };
 
+    opts.authOptions = opts.authOptions || {};
+    if (opts.authSource != null ) {
+      opts.authOptions.authSource = opts.authSource;
+    }
     if(opts.username) {
-      db.authenticate(opts.username, opts.password, opts.authOptions || {}, complete);
+      db.authenticate(opts.username, opts.password, opts.authOptions, complete);
     } else {
       complete(null, null);
     }

--- a/lib/db.js
+++ b/lib/db.js
@@ -19,7 +19,14 @@ function getReplicaSetServers(opts, mongodb){
       var port = parseInt(split[1]) || 27017;
       return new mongodb.Server(host, port);
     });
-   return  new mongodb.ReplSet(replServers);
+    var replSetOpts = {};
+    if (opts.replicaSetName !== undefined ) {
+      replSetOpts.replicaSet = opts.replicaSetName;
+    }
+    if (opts.ssl !== undefined) {
+      replSetOpts.ssl = true;
+    }
+   return  new mongodb.ReplSet(replServers, replSetOpts);
 }
 
 function getConnection(opts, cb) {
@@ -34,7 +41,11 @@ function getConnection(opts, cb) {
     svr = new mongodb.Server(opts.host, opts.port, {});
   }
 
-  new mongodb.Db(opts.db, svr, {safe: true}).open(function (err, db) {
+  var connectOpts = {safe: true};
+  if (opts.authSource != null ) {
+    connectOpts.authSource = opts.authSource;
+  }
+  new mongodb.Db(opts.db, svr, connectOpts).open(function (err, db) {
 		if (err) {
 			return cb(err);
 		}


### PR DESCRIPTION
@mboorstin plz review; should be backwards compatible is already installed on deploy for now (I had jacob look over it).

see also:  http://mongodb.github.io/node-mongodb-native/2.2/api/ReplSet.html and http://mongodb.github.io/node-mongodb-native/2.2/api/Db.html
